### PR TITLE
feat: Increase attachment size limit to 100MB

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,8 +61,8 @@ func extractHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Max file size: 10MB per file
-	if err := r.ParseMultipartForm(20 << 20); err != nil {
+	// Max file size: 100MB for all files in a single request
+	if err := r.ParseMultipartForm(100 << 20); err != nil {
 		http.Error(w, "Could not parse multipart form", http.StatusBadRequest)
 		return
 	}

--- a/internal/ocr/gemini_test.go
+++ b/internal/ocr/gemini_test.go
@@ -63,7 +63,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.ExtractText(context.Background(), []byte("fake image data"), "image/png", "test_doc")
+		result, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestExtractText(t *testing.T) {
 	})
 
 	t.Run("should return error when doc type is not supported", func(t *testing.T) {
-		_, err := client.ExtractText(context.Background(), []byte("fake image data"), "image/png", "unsupported_doc")
+		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "unsupported_doc")
 		if !errors.Is(err, ErrUnsupportedDocumentType) {
 			t.Errorf("expected error %v, but got %v", ErrUnsupportedDocumentType, err)
 		}
@@ -86,7 +86,7 @@ func TestExtractText(t *testing.T) {
 			return nil, errors.New("api error")
 		}
 
-		_, err := client.ExtractText(context.Background(), []byte("fake image data"), "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -99,7 +99,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), []byte("fake image data"), "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -120,7 +120,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), []byte("fake image data"), "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}


### PR DESCRIPTION
Increases the maximum attachment size for uploads to 100MB.

Also fixes broken tests in `internal/ocr/gemini_test.go` that were failing to compile due to a type mismatch in a function call.