### PR TITLE
feat: Support named image parts for documents

### DIFF
--- a/configs/document_types.yml
+++ b/configs/document_types.yml
@@ -1,7 +1,7 @@
 documents:
   driver_license:
     prompt: |
-      Please analyze the provided image of a Japanese driver's license (運転免許証).
+      Please analyze the provided front and back images of a Japanese driver's license (運転免許証). The back side of the license may contain the most recent information, such as a new address. Please prioritize information from the back side if there are discrepancies.
       Extract the following fields and return the result in a single, minified JSON object.
       If a field is not present, use an empty string "" as its value.
     json_structure:
@@ -11,10 +11,12 @@ documents:
       issue_date: "交付日"
       expiry_date: "有効期限"
       card_number: "免許の番号"
-    required_images: 2
+    image_parts:
+      - front
+      - back
   individual_number_card:
     prompt: |
-      Please analyze the provided image of a Individual Number Card (マイナンバーカード).
+      Please analyze the provided image of the front of a Japanese Individual Number Card (マイナンバーカード).
       Extract the following fields and return the result in a single, minified JSON object.
       If a field is not present, use an empty string "" as its value.
     json_structure:
@@ -25,4 +27,5 @@ documents:
       expiry_date: "有効期限"
       card_number: "マイナンバー"
       gender: "性別"
-    required_images: 1
+    image_parts:
+      - front

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Document struct {
-	Prompt         string            `yaml:"prompt"`
-	JSONStructure  map[string]string `yaml:"json_structure"`
-	RequiredImages int               `yaml:"required_images"`
+	Prompt        string            `yaml:"prompt"`
+	JSONStructure map[string]string `yaml:"json_structure"`
+	ImageParts    []string          `yaml:"image_parts"`
 }
 
 type Config struct {

--- a/internal/ocr/gemini_test.go
+++ b/internal/ocr/gemini_test.go
@@ -40,6 +40,7 @@ func TestExtractText(t *testing.T) {
 					"name": "name of the person",
 					"age":  "age of the person",
 				},
+				ImageParts: []string{"front"},
 			},
 		},
 	}
@@ -47,6 +48,7 @@ func TestExtractText(t *testing.T) {
 		genaiClient: mockModel,
 		config:      config,
 	}
+	mockImageData := map[string][]byte{"front": []byte("fake image data")}
 
 	t.Run("should extract text successfully", func(t *testing.T) {
 		mockModel.GenerateContentFunc = func(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error) {
@@ -63,7 +65,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
+		result, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -75,7 +77,7 @@ func TestExtractText(t *testing.T) {
 	})
 
 	t.Run("should return error when doc type is not supported", func(t *testing.T) {
-		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "unsupported_doc")
+		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "unsupported_doc")
 		if !errors.Is(err, ErrUnsupportedDocumentType) {
 			t.Errorf("expected error %v, but got %v", ErrUnsupportedDocumentType, err)
 		}
@@ -86,7 +88,7 @@ func TestExtractText(t *testing.T) {
 			return nil, errors.New("api error")
 		}
 
-		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -99,7 +101,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -120,7 +122,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), [][]byte{[]byte("fake image data")}, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}


### PR DESCRIPTION
This commit refactors the API to accept named image parts (e.g., `image_front`, `image_back`) instead of an undifferentiated list of images. This allows the service to distinguish between different parts of a document, such as the front and back of a driver's license.

Key changes:
- The `/api/v1/extract` endpoint now accepts multipart form fields like `image_front` and `image_back`.
- The `configs/document_types.yml` file has a new `image_parts` key to define the required named parts for each document type.
- The prompt for driver's licenses has been updated to instruct the AI to prioritize information from the back side, which often contains the most recent address.
- The OCR client in `internal/ocr/gemini.go` now labels each image part in the prompt sent to the Gemini API.
- Unit tests have been updated to reflect the new API structure and function signatures.