### PR TITLE
fix(ocr): Correct MIME type for Gemini API

### DIFF
--- a/internal/ocr/gemini.go
+++ b/internal/ocr/gemini.go
@@ -91,7 +91,7 @@ func (c *Client) ExtractText(ctx context.Context, imageDatas map[string][]byte, 
 
 		// Add a text part to label the image
 		prompt = append(prompt, genai.Text(fmt.Sprintf("\nImage part: %s", partName)))
-		prompt = append(prompt, genai.ImageData(effectiveMime, imageData))
+		prompt = append(prompt, genai.ImageData(strings.TrimPrefix(effectiveMime, "image/"), imageData))
 	}
 
 	resp, err := c.genaiClient.GenerateContent(ctx, prompt...)

--- a/internal/ocr/gemini_test.go
+++ b/internal/ocr/gemini_test.go
@@ -114,7 +114,7 @@ func TestExtractText(t *testing.T) {
 					{
 						Content: &genai.Content{
 							Parts: []genai.Part{
-								genai.ImageData("image/png", []byte("fake image data")),
+								genai.ImageData("png", []byte("fake image data")),
 							},
 						},
 					},


### PR DESCRIPTION
The Gemini API was receiving a MIME type with a duplicated prefix, such as "image/image/jpeg", resulting in a 400 Bad Request error. This was caused by the genai.ImageData function expecting only the MIME subtype (e.g., "jpeg") while the full type ("image/jpeg") was being passed.

This commit fixes the issue by stripping the "image/" prefix from the MIME type string before passing it to the genai.ImageData function.

The corresponding unit test has been updated to reflect this change.