### PR TITLE
feat: Support multiple MIME types for attachments

### DIFF
--- a/internal/ocr/gemini_test.go
+++ b/internal/ocr/gemini_test.go
@@ -48,10 +48,24 @@ func TestExtractText(t *testing.T) {
 		genaiClient: mockModel,
 		config:      config,
 	}
-	mockImageData := map[string][]byte{"front": []byte("fake image data")}
+	mockFileParts := map[string]FilePart{
+		"front": {Content: []byte("fake image data"), MimeType: "image/png"},
+	}
 
-	t.Run("should extract text successfully", func(t *testing.T) {
+	t.Run("should extract text successfully with supported mime type", func(t *testing.T) {
 		mockModel.GenerateContentFunc = func(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error) {
+			// Basic validation of the prompt structure
+			if len(parts) != 3 { // Prompt, Label, Blob
+				t.Errorf("expected 3 parts, got %d", len(parts))
+			}
+			blob, ok := parts[2].(genai.Blob)
+			if !ok {
+				t.Error("expected a genai.Blob part")
+			}
+			if blob.MIMEType != "image/png" {
+				t.Errorf("expected mime type image/png, got %s", blob.MIMEType)
+			}
+
 			return &genai.GenerateContentResponse{
 				Candidates: []*genai.Candidate{
 					{
@@ -65,7 +79,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
+		result, err := client.ExtractText(context.Background(), mockFileParts, "test_doc")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -76,8 +90,41 @@ func TestExtractText(t *testing.T) {
 		}
 	})
 
+	t.Run("should extract text successfully with PDF mime type", func(t *testing.T) {
+		pdfParts := map[string]FilePart{
+			"front": {Content: []byte("fake pdf data"), MimeType: "application/pdf"},
+		}
+		mockModel.GenerateContentFunc = func(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error) {
+			blob, ok := parts[2].(genai.Blob)
+			if !ok {
+				t.Error("expected a genai.Blob part")
+			}
+			if blob.MIMEType != "application/pdf" {
+				t.Errorf("expected mime type application/pdf, got %s", blob.MIMEType)
+			}
+			return &genai.GenerateContentResponse{
+				Candidates: []*genai.Candidate{{Content: &genai.Content{Parts: []genai.Part{genai.Text("{}")}}}},
+			}, nil
+		}
+
+		_, err := client.ExtractText(context.Background(), pdfParts, "test_doc")
+		if err != nil {
+			t.Errorf("unexpected error for PDF: %v", err)
+		}
+	})
+
+	t.Run("should return error when mime type is not supported", func(t *testing.T) {
+		unsupportedParts := map[string]FilePart{
+			"front": {Content: []byte("fake data"), MimeType: "application/zip"},
+		}
+		_, err := client.ExtractText(context.Background(), unsupportedParts, "test_doc")
+		if !errors.Is(err, ErrUnsupportedMimeType) {
+			t.Errorf("expected error %v, but got %v", ErrUnsupportedMimeType, err)
+		}
+	})
+
 	t.Run("should return error when doc type is not supported", func(t *testing.T) {
-		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "unsupported_doc")
+		_, err := client.ExtractText(context.Background(), mockFileParts, "unsupported_doc")
 		if !errors.Is(err, ErrUnsupportedDocumentType) {
 			t.Errorf("expected error %v, but got %v", ErrUnsupportedDocumentType, err)
 		}
@@ -88,7 +135,7 @@ func TestExtractText(t *testing.T) {
 			return nil, errors.New("api error")
 		}
 
-		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockFileParts, "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -101,7 +148,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockFileParts, "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -122,7 +169,7 @@ func TestExtractText(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.ExtractText(context.Background(), mockImageData, "image/png", "test_doc")
+		_, err := client.ExtractText(context.Background(), mockFileParts, "test_doc")
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}


### PR DESCRIPTION
This change refactors the file upload handling to support multiple MIME types, including `image/jpeg`, `image/png`, `image/webp`, and `application/pdf`.

The key changes are:
- Introduced an `ocr.FilePart` struct to encapsulate the content and MIME type of each uploaded file.
- Updated `extractHandler` in `cmd/api/main.go` to handle multipart uploads with different MIME types for each part.
- Modified `ocr.Client.ExtractText` in `internal/ocr/gemini.go` to accept a map of `FilePart`s and validate each file's MIME type against a list of supported types.
- Replaced `genai.ImageData` with the more generic `genai.Blob` to handle various file formats.
- Updated unit tests in `internal/ocr/gemini_test.go` to cover the new functionality, including tests for PDF files and unsupported MIME types.