### PR TITLE
refactor: サービスをライブラリとして利用可能にする

### DIFF
--- a/kensho/config.go
+++ b/kensho/config.go
@@ -1,4 +1,4 @@
-package configs
+package kensho
 
 import (
 	"fmt"

--- a/kensho/kensho.go
+++ b/kensho/kensho.go
@@ -1,4 +1,4 @@
-package ocr
+package kensho
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/google/generative-ai-go/genai"
-	"github.com/y-mitsuyoshi/kensho/internal/configs"
 	"google.golang.org/api/option"
 )
 
@@ -34,13 +33,18 @@ type GenerativeModel interface {
 // Client holds the genai client.
 type Client struct {
 	genaiClient GenerativeModel
-	config      *configs.Config
+	config      *Config
 }
 
 // NewClient creates a new client for the Gemini API.
-func NewClient(ctx context.Context, apiKey string, config *configs.Config) (*Client, error) {
+func NewClient(ctx context.Context, apiKey string, configPath string) (*Client, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("GEMINI_API_KEY is not set")
+	}
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
 	client, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))


### PR DESCRIPTION
この変更は、サービスを他のアプリケーションで簡単に再利用できるように、コードベースをライブラリとしてリファクタリングします。

主な変更点：
- コアロジック（OCRと設定）を`internal`ディレクトリから新しい公開`kensho`パッケージに移動しました。
- `cmd/api/main.go`を更新し、新しい`kensho`ライブラリを使用するようにしました。これにより、既存のサーバー機能は維持されます。
- `kensho.NewClient`関数を改善し、設定オブジェクトの代わりに設定ファイルのパスを受け取るようにしました。これにより、ライブラリの使いやすさが向上します。
- テストを更新し、新しいパッケージ構造とAPIの変更を反映しました。

このリファクタリングにより、`github.com/y-mitsuyoshi/kensho/kensho`をインポートすることで、他のGoプロジェクトでOCR機能を直接利用できるようになります。