### PR TITLE
refactor: Move handler logic to kensho and improve prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -81,13 +82,19 @@ func main() {
 	docType := "driver_license" // or "individual_number_card"
 
 	// Call the extraction method
-	jsonString, err := client.ExtractText(ctx, fileParts, docType)
+	data, err := client.Extract(ctx, fileParts, docType)
 	if err != nil {
-		log.Fatalf("Failed to extract text: %v", err)
+		log.Fatalf("Failed to extract data: %v", err)
 	}
 
-	// The result is a clean JSON string
-	fmt.Println(jsonString)
+	// The result is a map[string]interface{}
+	// You can easily marshal it to a JSON string for display
+	prettyJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal JSON: %v", err)
+	}
+
+	fmt.Println(string(prettyJSON))
 }
 ```
 

--- a/kensho/document_types.yml
+++ b/kensho/document_types.yml
@@ -7,8 +7,9 @@ documents:
       **Instructions**:
       1.  You will be given one or two images, labeled "front" and "back".
       2.  The back side may contain updated information (like a new address). If information appears on both sides (e.g., address), prioritize the information from the back side.
-      3.  Extract the fields listed in the "JSON Structure" section below.
-      4.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
+      3.  **If a field is blurry or impossible to read, return `null` for that specific field instead of guessing.**
+      4.  Extract the fields listed in the "JSON Structure" section below.
+      5.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
 
       **JSON Structure**:
       {
@@ -46,8 +47,9 @@ documents:
 
       **Instructions**:
       1.  You will be given an image labeled "front".
-      2.  Extract the fields listed in the "JSON Structure" section below.
-      3.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
+      2.  **If a field is blurry or impossible to read, return `null` for that specific field instead of guessing.**
+      3.  Extract the fields listed in the "JSON Structure" section below.
+      4.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
 
       **JSON Structure**:
       {


### PR DESCRIPTION
This commit refactors the application to improve modularity and enhances the AI's behavior.

Key changes:
- The multipart request parsing logic from `cmd/api/main.go` has been moved into a new `kensho.ParseRequest` function within the `kensho` library. This simplifies the HTTP handler significantly.
- The `kensho.ExtractText` function has been renamed to `kensho.Extract` and its return type is changed from a raw string to `map[string]interface{}`. The library now handles the JSON unmarshalling, providing a more robust API.
- The prompts in `configs/document_types.yml` have been updated to instruct Gemini to return `null` for fields that are blurry or unreadable, improving data quality.
- The `README.md` and unit tests have been updated to reflect these API changes.