### PR TITLE
Fix: Remove obsolete config copy from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /app
 
 COPY --from=builder /kensho/server /app/server
-# Copy configuration files required at runtime
-COPY --from=builder /src/configs /app/configs
 
 EXPOSE 8080
 


### PR DESCRIPTION
The Docker build was failing because it was trying to copy a `configs` directory that no longer exists.

The application has been updated to use an embedded configuration via `go:embed`, as seen in `kensho/embedded_config.go`. The main application in `cmd/api/main.go` initializes the client using this embedded config, making the file-based configuration and the corresponding `COPY` instruction in the Dockerfile obsolete.

This change removes the unnecessary `COPY` command, which fixes the build failure and aligns the Dockerfile with the current application behavior.