### PR TITLE
feat: Implement confidence scores, validation, masking, and forgery d…

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -49,7 +49,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func extractHandler(w http.ResponseWriter, r *http.Request) {
-	docType, fileParts, err := kensho.ParseRequest(r)
+	docType, fileParts, masking, err := kensho.ParseRequest(r)
 	if err != nil {
 		switch {
 		case errors.Is(err, kensho.ErrRequestBodyTooLarge):
@@ -62,7 +62,7 @@ func extractHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := kenshoClient.Extract(r.Context(), fileParts, docType)
+	result, err := kenshoClient.Extract(r.Context(), fileParts, docType, masking)
 	if err != nil {
 		if errors.Is(err, kensho.ErrUnsupportedDocumentType) || errors.Is(err, kensho.ErrUnsupportedMimeType) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -75,5 +75,5 @@ func extractHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(data)
+	json.NewEncoder(w).Encode(result)
 }

--- a/kensho/document_types.yml
+++ b/kensho/document_types.yml
@@ -10,25 +10,28 @@ documents:
       3.  **If a field is blurry or impossible to read, return `null` for that specific field instead of guessing.**
       4.  Extract the fields listed in the "JSON Structure" section below.
       5.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
+      6.  **Forgery Detection**: Analyze the image for any signs of tampering or forgery (e.g., inconsistent fonts, unnatural text placement, evidence of photo manipulation, unusual holograms).
 
       **JSON Structure**:
       {
-        "name": "氏名",
-        "address": "住所",
-        "birth_date": "生年月日",
-        "issue_date": "交付日",
-        "expiry_date": "有効期限",
-        "card_number": "免許の番号"
+        "name": { "value": "氏名", "confidence_score": "0.0-1.0" },
+        "address": { "value": "住所", "confidence_score": "0.0-1.0" },
+        "birth_date": { "value": "生年月日", "confidence_score": "0.0-1.0" },
+        "issue_date": { "value": "交付日", "confidence_score": "0.0-1.0" },
+        "expiry_date": { "value": "有効期限", "confidence_score": "0.0-1.0" },
+        "card_number": { "value": "免許の番号", "confidence_score": "0.0-1.0" },
+        "forgery_warning": { "has_signs_of_forgery": "boolean", "reason": "string describing evidence" }
       }
 
       **Example**:
       {
-        "name": "見本太郎",
-        "address": "東京都千代田区霞が関2-1-1",
-        "birth_date": "昭和60年1月1日",
-        "issue_date": "平成25年4月1日",
-        "expiry_date": "平成30年2月1日",
-        "card_number": "第123456789012号"
+        "name": { "value": "見本太郎", "confidence_score": 0.95 },
+        "address": { "value": "東京都千代田区霞が関2-1-1", "confidence_score": 0.92 },
+        "birth_date": { "value": "昭和60年1月1日", "confidence_score": 0.99 },
+        "issue_date": { "value": "平成25年4月1日", "confidence_score": 0.98 },
+        "expiry_date": { "value": "平成30年2月1日", "confidence_score": 0.97 },
+        "card_number": { "value": "第123456789012号", "confidence_score": 0.85 },
+        "forgery_warning": { "has_signs_of_forgery": true, "reason": "The font used for the address appears inconsistent with the rest of the document." }
       }
     json_structure:
       name: "氏名"
@@ -50,27 +53,30 @@ documents:
       2.  **If a field is blurry or impossible to read, return `null` for that specific field instead of guessing.**
       3.  Extract the fields listed in the "JSON Structure" section below.
       4.  Return **only** a single, minified JSON object containing the extracted data. Do not include any explanatory text, markdown, or any characters outside of the JSON object.
+      5.  **Forgery Detection**: Analyze the image for any signs of tampering or forgery (e.g., inconsistent fonts, unnatural text placement, evidence of photo manipulation).
 
       **JSON Structure**:
       {
-        "name": "氏名",
-        "address": "住所",
-        "birth_date": "生年月日",
-        "issue_date": "交付日",
-        "expiry_date": "有効期限",
-        "card_number": "マイナンバー",
-        "gender": "性別"
+        "name": { "value": "氏名", "confidence_score": "0.0-1.0" },
+        "address": { "value": "住所", "confidence_score": "0.0-1.0" },
+        "birth_date": { "value": "生年月日", "confidence_score": "0.0-1.0" },
+        "issue_date": { "value": "交付日", "confidence_score": "0.0-1.0" },
+        "expiry_date": { "value": "有効期限", "confidence_score": "0.0-1.0" },
+        "card_number": { "value": "マイナンバー", "confidence_score": "0.0-1.0" },
+        "gender": { "value": "性別", "confidence_score": "0.0-1.0" },
+        "forgery_warning": { "has_signs_of_forgery": "boolean", "reason": "string describing evidence" }
       }
 
       **Example**:
       {
-        "name": "見本太郎",
-        "address": "東京都千代田区紀尾井町1-3",
-        "birth_date": "平成1年1月1日",
-        "issue_date": "2016年1月1日",
-        "expiry_date": "2026年1月1日",
-        "card_number": "123456789012",
-        "gender": "男性"
+        "name": { "value": "見本太郎", "confidence_score": 0.95 },
+        "address": { "value": "東京都千代田区紀尾井町1-3", "confidence_score": 0.92 },
+        "birth_date": { "value": "平成1年1月1日", "confidence_score": 0.99 },
+        "issue_date": { "value": "2016年1月1日", "confidence_score": 0.98 },
+        "expiry_date": { "value": "2026年1月1日", "confidence_score": 0.97 },
+        "card_number": { "value": "123456789012", "confidence_score": 0.85 },
+        "gender": { "value": "男性", "confidence_score": 0.99 },
+        "forgery_warning": { "has_signs_of_forgery": false, "reason": "No obvious signs of forgery detected." }
       }
     json_structure:
       name: "氏名"

--- a/kensho/validation/validation.go
+++ b/kensho/validation/validation.go
@@ -1,0 +1,103 @@
+package validation
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ValidateDriverLicenseNumber validates the check digit of a Japanese driver's license number.
+func ValidateDriverLicenseNumber(number string) bool {
+	number = strings.ReplaceAll(number, " ", "")
+	number = strings.ReplaceAll(number, "第", "")
+	number = strings.ReplaceAll(number, "号", "")
+	if len(number) != 12 {
+		return false
+	}
+
+	// The check digit calculation is a weighted sum modulo 11.
+	// This is a common algorithm, but the specific weights for Japanese driver's licenses
+	// are not publicly documented. For this example, we'll use a simplified checksum logic.
+	// A real implementation would need the official algorithm.
+	sum := 0
+	for i := 0; i < 11; i++ {
+		digit, err := strconv.Atoi(string(number[i]))
+		if err != nil {
+			return false
+		}
+		// Example weighting (not the real one)
+		weights := []int{5, 4, 3, 2, 7, 6, 5, 4, 3, 2, 1}
+		if i < len(weights) { // defensive check
+			sum += digit * weights[i]
+		}
+	}
+
+	checkDigit, err := strconv.Atoi(string(number[11]))
+	if err != nil {
+		return false
+	}
+
+	// Simplified check digit logic
+	return (11-(sum%11))%10 == checkDigit
+}
+
+// ValidateMyNumber validates the check digit of a Japanese Individual Number (My Number).
+func ValidateMyNumber(number string) bool {
+	number = strings.ReplaceAll(number, "-", "")
+	if len(number) != 12 {
+		return false
+	}
+
+	n, err := strconv.Atoi(number[:11])
+	if err != nil {
+		return false
+	}
+
+	// Calculation logic based on public specification
+	sum := 0
+	for i := 0; i < 11; i++ {
+		digit := n % 10
+		n /= 10
+		var weight int
+		if i < 6 {
+			weight = i + 2
+		} else {
+			weight = i - 4
+		}
+		sum += digit * weight
+	}
+
+	remainder := sum % 11
+	checkDigit := 0
+	if remainder > 1 {
+		checkDigit = 11 - remainder
+	}
+
+	lastDigit, err := strconv.Atoi(string(number[11]))
+	if err != nil {
+		return false
+	}
+
+	return checkDigit == lastDigit
+}
+
+// ValidateDate checks if a given date string is a real calendar date.
+// It expects the format YYYY年MM月DD日 or similar, and does not handle Japanese eras.
+func ValidateDate(dateStr string) bool {
+	dateStr = strings.TrimSpace(dateStr)
+	if !strings.Contains(dateStr, "年") || !strings.Contains(dateStr, "月") || !strings.Contains(dateStr, "日") {
+		return false
+	}
+
+	// This doesn't handle era names yet.
+	// A more robust solution would involve a proper date parsing library that understands Japanese eras.
+	dateStr = strings.ReplaceAll(dateStr, "年", "-")
+	dateStr = strings.ReplaceAll(dateStr, "月", "-")
+	dateStr = strings.ReplaceAll(dateStr, "日", "")
+
+	// This is a simplified check and won't handle Japanese eras correctly.
+	// For example "昭和60年1月1日" would fail.
+	// A real implementation would require a library to convert eras to Gregorian years first.
+	_, err := time.Parse("2006-1-2", dateStr)
+	return err == nil
+}

--- a/kensho/validation/validation_test.go
+++ b/kensho/validation/validation_test.go
@@ -1,0 +1,72 @@
+package validation
+
+import "testing"
+
+func TestValidateDriverLicenseNumber(t *testing.T) {
+	testCases := []struct {
+		name     string
+		number   string
+		expected bool
+	}{
+		// Based on the dummy weights in the function, for "12345678901", the check digit is 2.
+		{"valid", "123456789012", true},
+		{"invalid check digit", "123456789013", false},
+		{"invalid length", "12345", false},
+		{"invalid char", "12345678901a", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidateDriverLicenseNumber(tc.number); got != tc.expected {
+				t.Errorf("expected %v, but got %v for number %s", tc.expected, got, tc.number)
+			}
+		})
+	}
+}
+
+func TestValidateMyNumber(t *testing.T) {
+	testCases := []struct {
+		name     string
+		number   string
+		expected bool
+	}{
+		// A known valid number and check digit
+		{"valid", "123456789018", true},
+		{"invalid check digit", "123456789012", false},
+		{"invalid length", "12345", false},
+		{"invalid char", "12345678901a", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidateMyNumber(tc.number); got != tc.expected {
+				t.Errorf("expected %v, but got %v for number %s", tc.expected, got, tc.number)
+			}
+		})
+	}
+}
+
+func TestValidateDate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		date     string
+		expected bool
+	}{
+		{"valid date", "2023年1月15日", true},
+		{"invalid date", "2023年2月30日", false},
+		{"valid date with space", " 2024年12月1日 ", true},
+		{"invalid format", "2023-01-15", false},
+		{"era date", "平成30年2月1日", false}, // Known limitation
+		{"empty", "", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidateDate(tc.date); got != tc.expected {
+				t.Errorf("expected %v, but got %v for date %s", tc.expected, got, tc.date)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…etection

This commit introduces a comprehensive set of features to enhance the document extraction capabilities of the Kensho application.

- Adds confidence scores to the API response for each extracted field.
- Implements data validation for driver's licenses, "My Number", and dates.
- Adds a `masking=true` parameter to enable masking of sensitive data.
- Implements forgery detection, adding a warning to the response if signs of tampering are detected.
- Updates and expands unit tests to cover all new functionality.

Known Limitations:
- Driver's license check digit validation uses a placeholder algorithm.
- Date validation does not support Japanese era names (e.g., 昭和, 平成, 令和).