### PR TITLE
feat: make image preprocessing optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,13 @@ make logs
 - サーバーは`image/png`、`image/jpeg`、`image/webp`をサポートしています。
 - 運転免許証（`driver_license`）の場合、`image_front`と`image_back`を送信できます。
 - マイナンバーカード（`individual_number_card`）の場合、`image_front`を送信します。
+- `preprocess=true` を追加すると、画像の前処理（傾き補正、ノイズ除去など）が有効になります。デフォルトは `false` です。
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/extract \
   -F "document_type=driver_license" \
-  -F "image_front=@/path/to/your/image.png"
+  -F "image_front=@/path/to/your/image.png" \
+  -F "preprocess=true"
 ```
 
 リクエストが成功すると、次のようなJSONレスポンスが返されます。

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -49,7 +49,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func extractHandler(w http.ResponseWriter, r *http.Request) {
-	docType, fileParts, masking, err := kensho.ParseRequest(r)
+	docType, fileParts, masking, preprocess, err := kensho.ParseRequest(r)
 	if err != nil {
 		switch {
 		case errors.Is(err, kensho.ErrRequestBodyTooLarge):
@@ -62,7 +62,7 @@ func extractHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := kenshoClient.Extract(r.Context(), fileParts, docType, masking)
+	result, err := kenshoClient.Extract(r.Context(), fileParts, docType, masking, preprocess)
 	if err != nil {
 		if errors.Is(err, kensho.ErrUnsupportedDocumentType) || errors.Is(err, kensho.ErrUnsupportedMimeType) {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/kensho/kensho_test.go
+++ b/kensho/kensho_test.go
@@ -163,7 +163,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -190,7 +190,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err == nil {
 			t.Error("expected an error for invalid JSON, but got nil")
 		}
@@ -204,7 +204,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", true)
+		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", true, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -224,7 +224,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		result, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -253,7 +253,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.Extract(context.Background(), pdfParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), pdfParts, "test_doc", false, false)
 		if err != nil {
 			t.Errorf("unexpected error for PDF: %v", err)
 		}
@@ -263,14 +263,14 @@ func TestExtract(t *testing.T) {
 		unsupportedParts := map[string]FilePart{
 			"front": {Content: []byte("fake data"), MimeType: "application/zip"},
 		}
-		_, err := client.Extract(context.Background(), unsupportedParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), unsupportedParts, "test_doc", false, false)
 		if !errors.Is(err, ErrUnsupportedMimeType) {
 			t.Errorf("expected error %v, but got %v", ErrUnsupportedMimeType, err)
 		}
 	})
 
 	t.Run("should return error when doc type is not supported", func(t *testing.T) {
-		_, err := client.Extract(context.Background(), mockFileParts, "unsupported_doc", false)
+		_, err := client.Extract(context.Background(), mockFileParts, "unsupported_doc", false, false)
 		if !errors.Is(err, ErrUnsupportedDocumentType) {
 			t.Errorf("expected error %v, but got %v", ErrUnsupportedDocumentType, err)
 		}
@@ -281,7 +281,7 @@ func TestExtract(t *testing.T) {
 			return nil, errors.New("api error")
 		}
 
-		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -294,7 +294,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}
@@ -315,7 +315,7 @@ func TestExtract(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false)
+		_, err := client.Extract(context.Background(), mockFileParts, "test_doc", false, false)
 		if err == nil {
 			t.Error("expected error, but got nil")
 		}


### PR DESCRIPTION
This commit introduces a new `preprocess` parameter to the extraction process. When this boolean parameter is set to true, the image will be preprocessed before being sent to Gemini. By default, preprocessing is disabled to avoid performance overhead.

The following changes were made:
- Added `preprocess` parameter to the `ParseRequest` function.
- The `Extract` function in the `kensho` client now accepts a `preprocess` flag.
- The API handler in `main.go` has been updated to support the new parameter.
- Tests have been updated to reflect the changes in function signatures.
- The `README.md` has been updated to document the new `preprocess` parameter.